### PR TITLE
Fix role lookup for permissions

### DIFF
--- a/BankManagementWPF/Security/RolePermissions.cs
+++ b/BankManagementWPF/Security/RolePermissions.cs
@@ -6,7 +6,7 @@ namespace BankManagementSystem.WPF.Security
     {
         public static Dictionary<string, List<Permission>> GetRolePermissions()
         {
-            return new Dictionary<string, List<Permission>>
+            return new Dictionary<string, List<Permission>>(System.StringComparer.OrdinalIgnoreCase)
             {
                 ["Administrator"] = new List<Permission>
                 {


### PR DESCRIPTION
## Summary
- ensure role names are matched without case-sensitivity when looking up permissions