### PR TITLE
Fix transaction access for old cashier accounts

### DIFF
--- a/BankBusinessLayer/RoleMapping.cs
+++ b/BankBusinessLayer/RoleMapping.cs
@@ -8,7 +8,7 @@ namespace BankBusinessLayer
         {
             { 1, "Administrator" },
             { 2, "Manager" },
-            { 3, "Cashier" },
+            { 3, "User" },
             { 4, "Viewer" }
         };
 
@@ -16,7 +16,7 @@ namespace BankBusinessLayer
         {
             { "Administrator", 1 },
             { "Manager", 2 },
-            { "Cashier", 3 },
+            { "User", 3 },
             { "Viewer", 4 }
         };
 

--- a/BankBusinessLayer/User.cs
+++ b/BankBusinessLayer/User.cs
@@ -66,6 +66,8 @@ namespace BankBusinessLayer
 
             if (UsersData.GetUserByUsername(username, ref FirstName, ref LastName, ref Email, ref Phone, ref Password, ref Role, ref Permission, ref UserID))
             {
+                if (Role.Equals("Cashier", System.StringComparison.OrdinalIgnoreCase))
+                    Role = "User";
                 return new User(UserID, FirstName, LastName, Email, Phone, username, Password, Role, Permission);
             }
             else
@@ -81,6 +83,8 @@ namespace BankBusinessLayer
 
             if (UsersData.GetUserByUsernameAndPassword(username, password, ref Role, ref Permission))
             {
+                if (Role.Equals("Cashier", System.StringComparison.OrdinalIgnoreCase))
+                    Role = "User";
                 return new User(UserID, FirstName, LastName, Email, Phone, username, password, Role, Permission);
             }
             else

--- a/BankManagementWPF/Security/RolePermissions.cs
+++ b/BankManagementWPF/Security/RolePermissions.cs
@@ -24,8 +24,14 @@ namespace BankManagementSystem.WPF.Security
                     Permission.ProcessDeposit, Permission.ProcessWithdraw, Permission.ProcessTransfer,
                     Permission.ViewTransactions, Permission.ApproveTransactions
                 },
-                // Other roles have no special permissions and are limited to the Home tab
-                ["Cashier"] = new List<Permission>(),
+                // Regular users can manage their own transactions
+                ["User"] = new List<Permission>
+                {
+                    Permission.ProcessDeposit,
+                    Permission.ProcessWithdraw,
+                    Permission.ProcessTransfer,
+                    Permission.ViewTransactions
+                },
                 ["Viewer"] = new List<Permission>()
             };
         }

--- a/BankManagementWPF/Views/AddNewUserView.xaml
+++ b/BankManagementWPF/Views/AddNewUserView.xaml
@@ -75,7 +75,7 @@
                             <StackPanel Margin="10">
                                 <RadioButton Content="👑 Administrator - Full system access" x:Name="AdminRoleRadio" GroupName="UserRole" Margin="0,5"/>
                                 <RadioButton Content="👤 Manager - User and client management" x:Name="ManagerRoleRadio" GroupName="UserRole" Margin="0,5"/>
-                                <RadioButton Content="💰 Cashier - Transaction processing only" x:Name="CashierRoleRadio" GroupName="UserRole" Margin="0,5" IsChecked="True"/>
+                                <RadioButton Content="👤 User - Personal transactions" x:Name="UserRoleRadio" GroupName="UserRole" Margin="0,5" IsChecked="True"/>
                                 <RadioButton Content="👁️ Viewer - Read-only access" x:Name="ViewerRoleRadio" GroupName="UserRole" Margin="0,5"/>
                             </StackPanel>
                         </GroupBox>

--- a/BankManagementWPF/Views/AddNewUserView.xaml.cs
+++ b/BankManagementWPF/Views/AddNewUserView.xaml.cs
@@ -50,8 +50,8 @@ namespace BankManagementSystem.WPF.Views
                 return "Administrator";
             if (ManagerRoleRadio.IsChecked == true)
                 return "Manager";
-            if (CashierRoleRadio.IsChecked == true)
-                return "Cashier";
+            if (UserRoleRadio.IsChecked == true)
+                return "User";
             return "Viewer";
         }
 

--- a/BankManagementWPF/Views/DepositView.xaml
+++ b/BankManagementWPF/Views/DepositView.xaml
@@ -18,7 +18,7 @@
         </StackPanel>
 
         <!-- Account Search -->
-        <GroupBox Grid.Row="1" Header="Select Account" Margin="0,0,0,20">
+        <GroupBox x:Name="AccountSearchGroup" Grid.Row="1" Header="Select Account" Margin="0,0,0,20">
             <StackPanel Margin="10">
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                     <TextBlock Text="Account Number:" VerticalAlignment="Center" Width="120"/>

--- a/BankManagementWPF/Views/DepositView.xaml.cs
+++ b/BankManagementWPF/Views/DepositView.xaml.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using BankBusinessLayer;
+using BankManagementSystem.WPF.Security;
 
 namespace BankManagementSystem.WPF.Views
 {
@@ -12,21 +13,29 @@ namespace BankManagementSystem.WPF.Views
         public DepositView()
         {
             InitializeComponent();
+
+            if (CurrentUserSession.CurrentUser?.Role == "User")
+            {
+                AccountSearchGroup.Visibility = Visibility.Collapsed;
+                AccountNumberTextBox.Text = CurrentUserSession.CurrentUser.Username;
+                LoadAccount(CurrentUserSession.CurrentUser.Username);
+            }
         }
 
-        private void FindAccount_Click(object sender, RoutedEventArgs e)
+        private void LoadAccount(string accountNumber)
         {
             AccountInfoBorder.Visibility = Visibility.Collapsed;
             DepositFormGroup.IsEnabled = false;
             ProcessDepositButton.IsEnabled = false;
             NewBalanceTextBlock.Text = string.Empty;
-            if (!Client.IsClientExist(AccountNumberTextBox.Text))
+
+            if (!Client.IsClientExist(accountNumber))
             {
-                MessageBox.Show($"Client Not Found [{AccountNumberTextBox.Text}] Try Another One", "Find", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show($"Client Not Found [{accountNumber}] Try Another One", "Find", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
-            _client = Client.Find(AccountNumberTextBox.Text);
+            _client = Client.Find(accountNumber);
             if (_client == null)
             {
                 MessageBox.Show("Failed to load client info", "Find", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -39,6 +48,11 @@ namespace BankManagementSystem.WPF.Views
             DepositFormGroup.IsEnabled = true;
             ProcessDepositButton.IsEnabled = true;
             DepositAmountTextBox.Focus();
+        }
+
+        private void FindAccount_Click(object sender, RoutedEventArgs e)
+        {
+            LoadAccount(AccountNumberTextBox.Text);
         }
 
         private void ProcessDeposit_Click(object sender, RoutedEventArgs e)

--- a/BankManagementWPF/Views/FindUserView.xaml
+++ b/BankManagementWPF/Views/FindUserView.xaml
@@ -54,7 +54,7 @@
                     <ComboBoxItem Content="All Roles"/>
                     <ComboBoxItem Content="Administrator"/>
                     <ComboBoxItem Content="Manager"/>
-                    <ComboBoxItem Content="Cashier"/>
+                    <ComboBoxItem Content="User"/>
                     <ComboBoxItem Content="Viewer"/>
                 </ComboBox>
 

--- a/BankManagementWPF/Views/FindUserView.xaml.cs
+++ b/BankManagementWPF/Views/FindUserView.xaml.cs
@@ -47,7 +47,7 @@ namespace BankManagementSystem.WPF.Views
         {
             1 => "Administrator",
             2 => "Manager",
-            3 => "Cashier",
+            3 => "User",
             _ => "Viewer"
         };
 

--- a/BankManagementWPF/Views/PermissionsView.xaml
+++ b/BankManagementWPF/Views/PermissionsView.xaml
@@ -33,7 +33,7 @@
                         <ListBox x:Name="RolesListBox" SelectionChanged="Role_SelectionChanged">
                             <ListBoxItem Content="👑 Administrator" Tag="Administrator"/>
                             <ListBoxItem Content="👤 Manager" Tag="Manager"/>
-                            <ListBoxItem Content="💰 Cashier" Tag="Cashier"/>
+                            <ListBoxItem Content="👤 User" Tag="User"/>
                             <ListBoxItem Content="👁️ Viewer" Tag="Viewer"/>
                         </ListBox>
                     </GroupBox>

--- a/BankManagementWPF/Views/TransactionsView.xaml
+++ b/BankManagementWPF/Views/TransactionsView.xaml
@@ -22,11 +22,11 @@
                     Background="#F44336" Foreground="White" FontSize="16" FontWeight="Bold"/>
             <Button x:Name="TransferButton" Content="🔄 Transfer" Height="80" Margin="10" Click="Transfer_Click"
                     Background="#2196F3" Foreground="White" FontSize="16" FontWeight="Bold"/>
-            <Button Content="📊 Transfer Logs" Height="80" Margin="10" Click="TransferLogs_Click"
+            <Button x:Name="TransferLogsButton" Content="📊 Transfer Logs" Height="80" Margin="10" Click="TransferLogs_Click"
                     Background="#FF9800" Foreground="White" FontSize="16" FontWeight="Bold"/>
-            <Button Content="💼 Total Balances" Height="80" Margin="10" Click="TotalBalances_Click"
+            <Button x:Name="TotalBalancesButton" Content="💼 Total Balances" Height="80" Margin="10" Click="TotalBalances_Click"
                     Background="#9C27B0" Foreground="White" FontSize="16" FontWeight="Bold"/>
-            <Button x:Name="ExportButton" Content="📈 All Transactions" Height="80" Margin="10" Click="AllTransactions_Click"
+            <Button x:Name="AllTransactionsButton" Content="📈 All Transactions" Height="80" Margin="10" Click="AllTransactions_Click"
                     Background="#607D8B" Foreground="White" FontSize="16" FontWeight="Bold"/>
         </UniformGrid>
 

--- a/BankManagementWPF/Views/TransactionsView.xaml.cs
+++ b/BankManagementWPF/Views/TransactionsView.xaml.cs
@@ -14,14 +14,35 @@ namespace BankManagementSystem.WPF.Views
 
         private void ApplyPermissions()
         {
-            DepositButton.Visibility = CurrentUserSession.HasPermission(Permission.ProcessDeposit)
-                ? Visibility.Visible : Visibility.Collapsed;
-            WithdrawButton.Visibility = CurrentUserSession.HasPermission(Permission.ProcessWithdraw)
-                ? Visibility.Visible : Visibility.Collapsed;
-            TransferButton.Visibility = CurrentUserSession.HasPermission(Permission.ProcessTransfer)
-                ? Visibility.Visible : Visibility.Collapsed;
-            ExportButton.Visibility = CurrentUserSession.HasPermission(Permission.ExportData)
-                ? Visibility.Visible : Visibility.Collapsed;
+            var role = CurrentUserSession.CurrentUser?.Role;
+
+            if (role == "User")
+            {
+                DepositButton.Visibility = Visibility.Visible;
+                WithdrawButton.Visibility = Visibility.Visible;
+                TransferButton.Visibility = Visibility.Visible;
+                AllTransactionsButton.Visibility = Visibility.Visible;
+                TransferLogsButton.Visibility = Visibility.Collapsed;
+                TotalBalancesButton.Visibility = Visibility.Collapsed;
+            }
+            else if (role == "Administrator" || role == "Manager")
+            {
+                DepositButton.Visibility = Visibility.Collapsed;
+                WithdrawButton.Visibility = Visibility.Collapsed;
+                TransferButton.Visibility = Visibility.Collapsed;
+                AllTransactionsButton.Visibility = Visibility.Collapsed;
+                TransferLogsButton.Visibility = Visibility.Visible;
+                TotalBalancesButton.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                DepositButton.Visibility = Visibility.Collapsed;
+                WithdrawButton.Visibility = Visibility.Collapsed;
+                TransferButton.Visibility = Visibility.Collapsed;
+                AllTransactionsButton.Visibility = Visibility.Collapsed;
+                TransferLogsButton.Visibility = Visibility.Collapsed;
+                TotalBalancesButton.Visibility = Visibility.Collapsed;
+            }
         }
 
         private void Deposit_Click(object sender, RoutedEventArgs e)

--- a/BankManagementWPF/Views/TransferView.xaml
+++ b/BankManagementWPF/Views/TransferView.xaml
@@ -19,7 +19,7 @@
             </StackPanel>
 
             <!-- From Account Section -->
-            <GroupBox Grid.Row="1" Header="From Account (Source)" Margin="0,0,0,15" Background="#E3F2FD">
+            <GroupBox x:Name="FromAccountGroup" Grid.Row="1" Header="From Account (Source)" Margin="0,0,0,15" Background="#E3F2FD">
                 <StackPanel Margin="10">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                         <TextBlock Text="Account Number:" VerticalAlignment="Center" Width="120"/>
@@ -37,7 +37,7 @@
             </GroupBox>
 
             <!-- To Account Section -->
-            <GroupBox Grid.Row="2" Header="To Account (Destination)" Margin="0,0,0,15" Background="#E8F5E8">
+            <GroupBox x:Name="ToAccountGroup" Grid.Row="2" Header="To Account (Destination)" Margin="0,0,0,15" Background="#E8F5E8">
                 <StackPanel Margin="10">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                         <TextBlock Text="Account Number:" VerticalAlignment="Center" Width="120"/>

--- a/BankManagementWPF/Views/TransferView.xaml.cs
+++ b/BankManagementWPF/Views/TransferView.xaml.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using BankBusinessLayer;
+using BankManagementSystem.WPF.Security;
 
 namespace BankManagementSystem.WPF.Views
 {
@@ -13,19 +14,26 @@ namespace BankManagementSystem.WPF.Views
         public TransferView()
         {
             InitializeComponent();
+
+            if (CurrentUserSession.CurrentUser?.Role == "User")
+            {
+                FromAccountGroup.Visibility = Visibility.Collapsed;
+                FromAccountTextBox.Text = CurrentUserSession.CurrentUser.Username;
+                LoadFromAccount(CurrentUserSession.CurrentUser.Username);
+            }
         }
 
-        private void FindFromAccount_Click(object sender, RoutedEventArgs e)
+        private void LoadFromAccount(string accountNumber)
         {
             FromAccountInfoBorder.Visibility = Visibility.Collapsed;
             TransferDetailsGroup.IsEnabled = false;
             ProcessTransferButton.IsEnabled = false;
-            if (!Client.IsClientExist(FromAccountTextBox.Text))
+            if (!Client.IsClientExist(accountNumber))
             {
                 MessageBox.Show("Source account not found.", "Find", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
-            _fromClient = Client.Find(FromAccountTextBox.Text);
+            _fromClient = Client.Find(accountNumber);
             if (_fromClient == null)
             {
                 MessageBox.Show("Failed to load source account.", "Find", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -35,6 +43,11 @@ namespace BankManagementSystem.WPF.Views
             FromBalanceTextBlock.Text = _fromClient.Balance.ToString("C");
             FromAccountInfoBorder.Visibility = Visibility.Visible;
             EnableTransferDetails();
+        }
+
+        private void FindFromAccount_Click(object sender, RoutedEventArgs e)
+        {
+            LoadFromAccount(FromAccountTextBox.Text);
         }
 
         private void FindToAccount_Click(object sender, RoutedEventArgs e)

--- a/BankManagementWPF/Views/UpdateUserView.xaml
+++ b/BankManagementWPF/Views/UpdateUserView.xaml
@@ -68,7 +68,7 @@
             <ComboBox Grid.Row="3" Grid.Column="1" x:Name="PermissionComboBox" Width="150">
                 <ComboBoxItem Content="Administrator"/>
                 <ComboBoxItem Content="Manager"/>
-                <ComboBoxItem Content="Cashier"/>
+                <ComboBoxItem Content="User"/>
                 <ComboBoxItem Content="Viewer"/>
             </ComboBox>
         </Grid>

--- a/BankManagementWPF/Views/UsersListView.xaml
+++ b/BankManagementWPF/Views/UsersListView.xaml
@@ -35,8 +35,8 @@
                 </StackPanel>
                 <StackPanel HorizontalAlignment="Center">
                     <TextBlock Text="💰" FontSize="20" HorizontalAlignment="Center"/>
-                    <TextBlock Text="Cashiers" FontWeight="Bold" HorizontalAlignment="Center" FontSize="12"/>
-                    <TextBlock x:Name="CashierCountTextBlock" FontSize="16" Foreground="#4CAF50" HorizontalAlignment="Center"/>
+                    <TextBlock Text="Users" FontWeight="Bold" HorizontalAlignment="Center" FontSize="12"/>
+                    <TextBlock x:Name="UserCountTextBlock" FontSize="16" Foreground="#4CAF50" HorizontalAlignment="Center"/>
                 </StackPanel>
                 <StackPanel HorizontalAlignment="Center">
                     <TextBlock Text="👁️" FontSize="20" HorizontalAlignment="Center"/>
@@ -65,7 +65,7 @@
                         <ComboBoxItem Content="All Roles"/>
                         <ComboBoxItem Content="Administrator"/>
                         <ComboBoxItem Content="Manager"/>
-                        <ComboBoxItem Content="Cashier"/>
+                        <ComboBoxItem Content="User"/>
                         <ComboBoxItem Content="Viewer"/>
                     </ComboBox>
 

--- a/BankManagementWPF/Views/UsersListView.xaml.cs
+++ b/BankManagementWPF/Views/UsersListView.xaml.cs
@@ -67,7 +67,7 @@ namespace BankManagementSystem.WPF.Views
         {
             1 => "Administrator",
             2 => "Manager",
-            3 => "Cashier",
+            3 => "User",
             _ => "Viewer"
         };
 
@@ -80,8 +80,8 @@ namespace BankManagementSystem.WPF.Views
             if (ManagerCountTextBlock != null)
                 ManagerCountTextBlock.Text = _rows.Count(r => r.Role == "Manager").ToString();
 
-            if (CashierCountTextBlock != null)
-                CashierCountTextBlock.Text = _rows.Count(r => r.Role == "Cashier").ToString();
+            if (UserCountTextBlock != null)
+                UserCountTextBlock.Text = _rows.Count(r => r.Role == "User").ToString();
 
             if (ViewerCountTextBlock != null)
                 ViewerCountTextBlock.Text = _rows.Count(r => r.Role == "Viewer").ToString();

--- a/BankManagementWPF/Views/WithdrawView.xaml
+++ b/BankManagementWPF/Views/WithdrawView.xaml
@@ -19,7 +19,7 @@
         </StackPanel>
 
         <!-- Account Search -->
-        <GroupBox Grid.Row="1" Header="Select Account" Margin="0,0,0,20">
+        <GroupBox x:Name="AccountSearchGroup" Grid.Row="1" Header="Select Account" Margin="0,0,0,20">
             <StackPanel Margin="10">
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                     <TextBlock Text="Account Number:" VerticalAlignment="Center" Width="120"/>

--- a/BankManagementWPF/Views/WithdrawView.xaml.cs
+++ b/BankManagementWPF/Views/WithdrawView.xaml.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using BankBusinessLayer;
+using BankManagementSystem.WPF.Security;
 
 namespace BankManagementSystem.WPF.Views
 {
@@ -12,22 +13,30 @@ namespace BankManagementSystem.WPF.Views
         public WithdrawView()
         {
             InitializeComponent();
+
+            if (CurrentUserSession.CurrentUser?.Role == "User")
+            {
+                AccountSearchGroup.Visibility = Visibility.Collapsed;
+                AccountNumberTextBox.Text = CurrentUserSession.CurrentUser.Username;
+                LoadAccount(CurrentUserSession.CurrentUser.Username);
+            }
         }
 
-        private void FindAccount_Click(object sender, RoutedEventArgs e)
+        private void LoadAccount(string accountNumber)
         {
             AccountInfoBorder.Visibility = Visibility.Collapsed;
             WithdrawFormGroup.IsEnabled = false;
             ProcessWithdrawButton.IsEnabled = false;
             NewBalanceTextBlock.Text = string.Empty;
             ValidationMessageTextBlock.Visibility = Visibility.Collapsed;
-            if (!Client.IsClientExist(AccountNumberTextBox.Text))
+
+            if (!Client.IsClientExist(accountNumber))
             {
-                MessageBox.Show($"Client Not Found [{AccountNumberTextBox.Text}] Try Another One", "Find", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show($"Client Not Found [{accountNumber}] Try Another One", "Find", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
-            _client = Client.Find(AccountNumberTextBox.Text);
+            _client = Client.Find(accountNumber);
             if (_client == null)
             {
                 MessageBox.Show("Failed to load client info", "Find", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -43,6 +52,11 @@ namespace BankManagementSystem.WPF.Views
             WithdrawFormGroup.IsEnabled = true;
             ProcessWithdrawButton.IsEnabled = true;
             WithdrawAmountTextBox.Focus();
+        }
+
+        private void FindAccount_Click(object sender, RoutedEventArgs e)
+        {
+            LoadAccount(AccountNumberTextBox.Text);
         }
 
         private void WithdrawAmount_TextChanged(object sender, TextChangedEventArgs e)

--- a/Database/CreateTables.sql
+++ b/Database/CreateTables.sql
@@ -65,8 +65,8 @@ USE BankDB;
 INSERT INTO Users (Username, Password, FirstName, LastName, Email, Phone, Address, Role, Permission) VALUES
 ('admin', 'admin123', 'Nguyễn', 'Quản Trị', 'admin@bank.com', '0901234567', '123 Đường ABC, TP.HCM', 'Administrator', 1),
 ('manager', 'manager123', 'Trần', 'Giám Đốc', 'manager@bank.com', '0902345678', '456 Đường DEF, TP.HCM', 'Manager', 2),
-('cashier1', 'cashier123', 'Lê', 'Thu Ngân', 'cashier1@bank.com', '0903456789', '789 Đường GHI, TP.HCM', 'Cashier', 3),
-('teller1', 'teller123', 'Phạm', 'Giao Dịch', 'teller1@bank.com', '0904567890', '321 Đường JKL, TP.HCM', 'Cashier', 3),
+('cashier1', 'cashier123', 'Lê', 'Thu Ngân', 'cashier1@bank.com', '0903456789', '789 Đường GHI, TP.HCM', 'User', 3),
+('teller1', 'teller123', 'Phạm', 'Giao Dịch', 'teller1@bank.com', '0904567890', '321 Đường JKL, TP.HCM', 'User', 3),
 ('auditor', 'auditor123', 'Đỗ', 'Kiểm Toán', 'auditor@bank.com', '0906666666', '789 Đường MNO, TP.HCM', 'Viewer', 4),
 ('support', 'support123', 'Vũ', 'Hỗ Trợ', 'support@bank.com', '0907777777', '987 Đường PQR, TP.HCM', 'Viewer', 4);
 


### PR DESCRIPTION
## Summary
- map the legacy "Cashier" role to "User" when loading user data
- users with the renamed role can now access the Transactions tab